### PR TITLE
Fixed NullReference when disposing client

### DIFF
--- a/src/Tibber.Sdk/TibberApiClient.cs
+++ b/src/Tibber.Sdk/TibberApiClient.cs
@@ -72,7 +72,7 @@ namespace Tibber.Sdk
 
         public void Dispose()
         {
-            _realTimeMeasurementListener.Dispose();
+            _realTimeMeasurementListener?.Dispose();
             _httpClient.Dispose();
         }
 


### PR DESCRIPTION
Unless StartRealTimeMeasurementListener has been called after TibberApiClient has been constructed, the Dispose method will fail since _realTimeMeasurementListener is null.