### PR TITLE
Fix resubscription for graphql-ws

### DIFF
--- a/src/Tibber.Sdk/RealTimeMeasurementListener.cs
+++ b/src/Tibber.Sdk/RealTimeMeasurementListener.cs
@@ -177,6 +177,7 @@ namespace Tibber.Sdk
             Trace.WriteLine($"subscribe to {homeId}");
 
             await ExecuteStreamRequest(
+                //$@"{{""payload"":{{""query"":""subscription{{testMeasurement(count:2, complete:false){{timestamp,power,powerReactive,powerProduction,powerProductionReactive,accumulatedConsumption,accumulatedConsumptionLastHour,accumulatedProduction,accumulatedProductionLastHour,accumulatedCost,accumulatedReward,currency,minPower,averagePower,maxPower,minPowerProduction,maxPowerProduction,voltagePhase1,voltagePhase2,voltagePhase3,currentL1,currentL2,currentL3,lastMeterConsumption,lastMeterProduction,powerFactor,signalStrength}}}}"",""variables"":{{}},""extensions"":{{}}}},""type"":""subscribe"",""id"":""{subscriptionId}""}}",
                 $@"{{""payload"":{{""query"":""subscription{{liveMeasurement(homeId:\""{homeId}\""){{timestamp,power,powerReactive,powerProduction,powerProductionReactive,accumulatedConsumption,accumulatedConsumptionLastHour,accumulatedProduction,accumulatedProductionLastHour,accumulatedCost,accumulatedReward,currency,minPower,averagePower,maxPower,minPowerProduction,maxPowerProduction,voltagePhase1,voltagePhase2,voltagePhase3,currentL1,currentL2,currentL3,lastMeterConsumption,lastMeterProduction,powerFactor,signalStrength}}}}"",""variables"":{{}},""extensions"":{{}}}},""type"":""subscribe"",""id"":""{subscriptionId}""}}",
                 cancellationToken);
 
@@ -517,6 +518,9 @@ namespace Tibber.Sdk
         {
             [JsonProperty("liveMeasurement")]
             public RealTimeMeasurement RealTimeMeasurement { get; set; }
+
+            [JsonProperty("testMeasurement")]
+            public RealTimeMeasurement TestMeasurement { set { RealTimeMeasurement = value; } }
         }
 
         private class HomeStreamObserverCollection


### PR DESCRIPTION
Unsubscribe before resubscribing with the same subsciption id. Otherwise graphql-ws server responds with "Subscriber for ${id} already exists".